### PR TITLE
Fixed broken links and added feedback form

### DIFF
--- a/practicals/IDE-setup/linux-setup.md
+++ b/practicals/IDE-setup/linux-setup.md
@@ -74,7 +74,7 @@ int main() {
 ```
 
 {:.note2}
-This file is also available under [`./setup/Resources/hello.c`](/practicals/setup/Resources/hello.c).
+This file is also available under [`./setup/Resources/hello.c`](https://mechatronicsystems-group.github.io//Integrated-Embedded-Systems/practicals/IDE-setup/Resources/hello.c).
 
 Save the file, and try and compile the program. Open a new terminal in VSCode with `Terminal → New Terminal` menu at the top left of the GUI or the keyboard shortcut and run:
 
@@ -109,7 +109,7 @@ While it is installing, you may be asked to install other pre-requisites in a po
 
 If you don't see any pop-ups, that is fine - you will be prompted in the next step.
 
-Once the **stm32-for-vscode** extension is installed, download the [`STM32 Programming Template`](/STM32-Programming-Template) available in the Integrating Embedded Systems repo. Save it to a convenient location, and open the folder in VSCode using `File → Open Folder ...`
+Once the **stm32-for-vscode** extension is installed, download the [`STM32 Programming Template`](https://github.com/MechatronicSystems-Group/Integrated-Embedded-Systems/tree/main/STM32-Programming-Template) available in the Integrating Embedded Systems repo. Save it to a convenient location, and open the folder in VSCode using `File → Open Folder ...`
 
 Once it is open, you should see the STM32 plugin window available on the left hand side of the screen. It is the **small block with a dot and the letters ST under the extension marketplace icon**
 

--- a/practicals/IDE-setup/mac-setup.md
+++ b/practicals/IDE-setup/mac-setup.md
@@ -57,7 +57,7 @@ int main() {
 ```
 
 {:.note2}
-This file is also available under [`./setup/Resources/hello.c`](/practicals/setup/Resources/hello.c).
+This file is also available under [`./setup/Resources/hello.c`](https://mechatronicsystems-group.github.io//Integrated-Embedded-Systems/practicals/IDE-setup/Resources/hello.c).
 
 Save the file, and try and compile the program. Open a new terminal in VSCode with `Terminal → New Terminal` menu at the top left of the GUI or the keyboard shortcut and run:
 
@@ -92,7 +92,7 @@ This extension is also available in the extensions marketplace, similar to the C
 
 If you don't see any pop-ups, that is fine - you will be prompted in the next step.
 
-Once the **stm32-for-vscode** extension is installed, download the [`STM32 Programming Template`](/STM32-Programming-Template) available in the Integrating Embedded Systems repo. Save it to a convenient location, and open the folder in VSCode using `File → Open Folder ...`.
+Once the **stm32-for-vscode** extension is installed, download the [`STM32 Programming Template`](https://github.com/MechatronicSystems-Group/Integrated-Embedded-Systems/tree/main/STM32-Programming-Template) available in the Integrating Embedded Systems repo. Save it to a convenient location, and open the folder in VSCode using `File → Open Folder ...`.
 
 Once it is open, you should see the STM32 plugin window available on the left hand side of the screen. It is the **small block with a dot and the letters ST under the extension marketplace icon**
 

--- a/practicals/IDE-setup/windows-setup.md
+++ b/practicals/IDE-setup/windows-setup.md
@@ -84,7 +84,7 @@ int main() {
 ```
 
 {:.note2}
-This file is also available under [`./setup/Resources/hello.c`](/practicals/setup/Resources/hello.c).
+This file is also available under [`./setup/Resources/hello.c`](https://mechatronicsystems-group.github.io//Integrated-Embedded-Systems/practicals/IDE-setup/Resources/hello.c).
 
 Save the file, and try and compile the program. Open a new terminal in VSCode with `Terminal → New Terminal` menu at the top left of the GUI or the keyboard shortcut and run:
 
@@ -119,7 +119,7 @@ While it is installing, you may be asked to install other pre-requisites in a po
 
 If you don't see any pop-ups, that is fine - you will be prompted in the next step.
 
-Once the **stm32-for-vscode** extension is installed, download the [`STM32 Programming Template`](/STM32-Programming-Template) available in the Integrating Embedded Systems repo. Save it to a convenient location, and open the folder in VSCode using `File → Open Folder ...`
+Once the **stm32-for-vscode** extension is installed, download the [`STM32 Programming Template`](https://github.com/MechatronicSystems-Group/Integrated-Embedded-Systems/tree/main/STM32-Programming-Template) available in the Integrating Embedded Systems repo. Save it to a convenient location, and open the folder in VSCode using `File → Open Folder ...`
 
 Once it is open, you should see the STM32 plugin window available on the left hand side of the screen. It is the **small block with a dot and the letters ST under the extension marketplace icon**
 

--- a/practicals/index.md
+++ b/practicals/index.md
@@ -22,7 +22,7 @@ nav_order: 4
 
 
 {:.important}
-This practical series is new to the course. We require your feedback so that we can improve these practicals not only for next year but for the following weeks’ practicals. We ask that you take a few minutes to fill out the following [form](https://youtu.be/dQw4w9WgXcQ?si=labcCZXC0vl52rMY) so that we can improve this practical series.
+This practical series is new to the course. We require your feedback so that we can improve these practicals not only for next year but for the following weeks’ practicals. We ask that you take a few minutes to fill out the following [form](https://forms.office.com/r/bMUfettP7m) so that we can improve this practical series.
 
 ## Practical Sessions
 

--- a/practicals/practical_0/index.md
+++ b/practicals/practical_0/index.md
@@ -7,6 +7,9 @@ parent: Practicals
 # Practical 0: Workbench Equipment
 This practical looks to remind you of (or possibly introduce you to!) the functionality of the workbench equipment available in EM101, or any of the other UCT electronics labs. This equipment will be crucial for completing the rest of the MEC4126F practicals, so please take your time to familiarize yourself with the equipment now.
 
+{:.important}
+> Please use the [feedback form](https://forms.office.com/r/bMUfettP7m) to give us feedback on this practical and to report broken/faulty equipment.
+
 Table of Contents
 =================
 


### PR DESCRIPTION
Fixed the broken links found on the IDE-setup pages, created a practical feedback form and linked the form to the appropriate places.
